### PR TITLE
fix: packets, serializers, syncers 'n stuff

### DIFF
--- a/src/main/java/dev/sebastianb/wackyvessels/WackyVessels.java
+++ b/src/main/java/dev/sebastianb/wackyvessels/WackyVessels.java
@@ -3,6 +3,7 @@ package dev.sebastianb.wackyvessels;
 import dev.sebastianb.wackyvessels.block.WackyVesselsBlocks;
 import dev.sebastianb.wackyvessels.entity.WackyVesselsBlockEntities;
 import dev.sebastianb.wackyvessels.entity.WackyVesselsEntityTypes;
+import dev.sebastianb.wackyvessels.entity.vessels.AbstractVesselEntity;
 import dev.sebastianb.wackyvessels.network.WackyVesselsPackets;
 import dev.sebastianb.wackyvessels.registries.WackyVesselsScreenHandlerRegistry;
 import net.fabricmc.api.ModInitializer;
@@ -16,6 +17,7 @@ public class WackyVessels implements ModInitializer {
         WackyVesselsEntityTypes.register();
         WackyVesselsScreenHandlerRegistry.register();
         WackyVesselsPackets.register();
+        AbstractVesselEntity.initClass();
     }
 
 }

--- a/src/main/java/dev/sebastianb/wackyvessels/block/helm/VesselHelmEntity.java
+++ b/src/main/java/dev/sebastianb/wackyvessels/block/helm/VesselHelmEntity.java
@@ -2,17 +2,13 @@ package dev.sebastianb.wackyvessels.block.helm;
 
 import dev.sebastianb.wackyvessels.client.gui.VesselHelmScreenHandler;
 import dev.sebastianb.wackyvessels.entity.WackyVesselsBlockEntities;
-import net.fabricmc.fabric.api.block.entity.BlockEntityClientSerializable;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
-import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.screen.ScreenHandler;
-import net.minecraft.screen.ScreenHandlerContext;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
@@ -34,7 +30,7 @@ public class VesselHelmEntity extends BlockEntity implements ExtendedScreenHandl
     @Nullable
     @Override
     public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
-        return new VesselHelmScreenHandler(syncId, inv, ScreenHandlerContext.create(world, pos));
+        return new VesselHelmScreenHandler(syncId, world, pos);
     }
 
     // writes data in the world to the client. Called on the server and sends data off to the client

--- a/src/main/java/dev/sebastianb/wackyvessels/client/gui/VesselHelmScreen.java
+++ b/src/main/java/dev/sebastianb/wackyvessels/client/gui/VesselHelmScreen.java
@@ -5,42 +5,22 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ScreenTexts;
-import net.minecraft.client.gui.screen.ingame.BeaconScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
-import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.network.PacketByteBuf;
-import net.minecraft.screen.ScreenHandler;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
-import net.minecraft.text.TranslatableText;
-import net.minecraft.util.math.BlockPos;
-
-import java.util.Optional;
 
 @Environment(EnvType.CLIENT)
 public class VesselHelmScreen extends HandledScreen<VesselHelmScreenHandler> {
 
-    private VesselHelmScreenHandler handler;
+    private final VesselHelmScreenHandler handler;
 
     public VesselHelmScreen(VesselHelmScreenHandler handler, PlayerInventory inventory, Text title) {
         super(handler, inventory, title);
         this.handler = handler;
-    }
-
-    //This method will try to get the Position from the ScreenHandler, as ScreenRendering only happens on the client we
-    //get the ScreenHandler instance here which has the correct BlockPos in it!
-    private static BlockPos getBlockPosition(ScreenHandler handler) {
-        if (handler instanceof VesselHelmScreenHandler) {
-            return ((VesselHelmScreenHandler) handler).getPos();
-        } else {
-            return BlockPos.ORIGIN;
-        }
     }
 
     @Override
@@ -53,9 +33,8 @@ public class VesselHelmScreen extends HandledScreen<VesselHelmScreenHandler> {
     private void addAssemblyButton() {
         this.addDrawableChild(new ButtonWidget(this.width / 2 - 100, 196, 200, 20, ScreenTexts.DONE, (button) -> {
             // sends the location of helm to server for verification and creation
-            PacketByteBuf buf = PacketByteBufs.create();
-            buf.writeBlockPos(getBlockPosition(handler));
-            ClientPlayNetworking.send(Constants.Packets.VESSEL_HELM_MOUNT, buf);
+
+            ClientPlayNetworking.send(Constants.Packets.VESSEL_HELM_MOUNT, PacketByteBufs.empty());
 
         }));
     }

--- a/src/main/java/dev/sebastianb/wackyvessels/client/gui/VesselHelmScreenHandler.java
+++ b/src/main/java/dev/sebastianb/wackyvessels/client/gui/VesselHelmScreenHandler.java
@@ -2,31 +2,28 @@ package dev.sebastianb.wackyvessels.client.gui;
 
 import dev.sebastianb.wackyvessels.block.WackyVesselsBlocks;
 import dev.sebastianb.wackyvessels.registries.WackyVesselsScreenHandlerRegistry;
-import dev.sebastianb.wackyvessels.registries.WackyVesselsScreenRegistry;
-import net.minecraft.block.Blocks;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerContext;
-import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import org.jetbrains.annotations.Nullable;
 
 public class VesselHelmScreenHandler extends ScreenHandler {
 
-    private BlockPos pos;
+    private final BlockPos pos;
     private ScreenHandlerContext context;
 
     public VesselHelmScreenHandler(int syncId, Inventory inventory, PacketByteBuf buf) {
         super(WackyVesselsScreenHandlerRegistry.VESSEL_HELM_SCREEN, syncId);
         pos = buf.readBlockPos(); // reads from block entity
     }
-    public VesselHelmScreenHandler(int syncId, Inventory inventory, ScreenHandlerContext context) {
-        super(WackyVesselsScreenHandlerRegistry.VESSEL_HELM_SCREEN, syncId);
-        this.context = context;
 
+    public VesselHelmScreenHandler(int syncId, World world, BlockPos pos) {
+        super(WackyVesselsScreenHandlerRegistry.VESSEL_HELM_SCREEN, syncId);
+        this.context = ScreenHandlerContext.create(world, pos);
+        this.pos = pos;
     }
 
     // used by screen class

--- a/src/main/java/dev/sebastianb/wackyvessels/entity/vessels/AbstractVesselEntity.java
+++ b/src/main/java/dev/sebastianb/wackyvessels/entity/vessels/AbstractVesselEntity.java
@@ -4,7 +4,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
@@ -16,11 +15,13 @@ import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtHelper;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
-import org.apache.commons.lang3.SerializationUtils;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -32,45 +33,73 @@ public abstract class AbstractVesselEntity extends MobEntity {
 
     protected HashSet<BlockPos> vesselBlockPositions = new HashSet<>();
 
-    protected HashMap<BlockPos, BlockState> relativeVesselBlockPositions = new HashMap<>(); // coords of each block relative to helm
-    protected HashMap<BlockPos, BlockEntity> relativeVesselBlockEntity = new HashMap<>(); // coords of each block entity (like chests) relative to helm
+    protected Map<BlockPos, BlockState> relativeVesselBlockPositions = new HashMap<>(); // coords of each block relative to helm
+    protected Map<BlockPos, BlockEntity> relativeVesselBlockEntity = new HashMap<>(); // coords of each block entity (like chests) relative to helm
 
     protected boolean setModelData = false;
 
-
-    private static final TrackedData<HashMap<BlockPos, BlockState>> VESSEL_MODEL_DATA = DataTracker.registerData(AbstractVesselEntity.class, new TrackedDataHandler<>() {
+    private static final TrackedData<Map<BlockPos, BlockState>> VESSEL_MODEL_DATA = DataTracker.registerData(AbstractVesselEntity.class, new TrackedDataHandler<>() {
         @Override
-        public void write(PacketByteBuf buf, HashMap<BlockPos, BlockState> value) {
-            buf.writeByteArray(SerializationUtils.serialize(value)); // converts the hashmap
+        public void write(PacketByteBuf buf, Map<BlockPos, BlockState> value) {
+            buf.writeInt(value.size());
+            for (Map.Entry<BlockPos, BlockState> e : value.entrySet()) {
+                buf.writeLong(e.getKey().asLong());
+                buf.writeInt(Block.getRawIdFromState(e.getValue()));
+            }
         }
 
         @Override
-        public HashMap<BlockPos, BlockState> read(PacketByteBuf buf) {
-            return SerializationUtils.deserialize(buf.readByteArray()); // probably reads the hashmap from buf
+        public Map<BlockPos, BlockState> read(PacketByteBuf buf) {
+            int size = buf.readInt();
+            Map<BlockPos, BlockState> map = new HashMap<>(size);
+            for (int i = 0; i < size; i++) {
+                map.put(BlockPos.fromLong(buf.readLong()), Block.getStateFromRawId(buf.readInt()));
+            }
+            return map;
         }
 
         @Override
-        public HashMap<BlockPos, BlockState> copy(HashMap<BlockPos, BlockState> value) {
-            return value;
+        public Map<BlockPos, BlockState> copy(Map<BlockPos, BlockState> value) {
+            return new HashMap<>(value);
+        }
+    });
+
+    private static final TrackedData<Map<BlockPos, BlockEntity>> VESSEL_BLOCK_ENTITY_DATA = DataTracker.registerData(AbstractVesselEntity.class, new TrackedDataHandler<>() {
+        @Override
+        public void write(PacketByteBuf buf, Map<BlockPos, BlockEntity> value) {
+            buf.writeInt(value.size());
+            for (Map.Entry<BlockPos, BlockEntity> e : value.entrySet()) {
+                buf.writeLong(e.getKey().asLong());
+                buf.writeString(Registry.BLOCK_ENTITY_TYPE.getId(e.getValue().getType()).toString());
+                buf.writeNbt(e.getValue().writeNbt(new NbtCompound()));
+            }
+        }
+
+        @Override
+        public Map<BlockPos, BlockEntity> read(PacketByteBuf buf) {
+            int size = buf.readInt();
+            Map<BlockPos, BlockEntity> map = new HashMap<>(size);
+            for (int i = 0; i < size; i++) {
+                BlockPos blockPos = BlockPos.fromLong(buf.readLong());
+                map.put(blockPos, Registry.BLOCK_ENTITY_TYPE.get(new Identifier(buf.readString())).instantiate(blockPos, Blocks.AIR.getDefaultState())); //figure out blocks from type?
+            }
+            return map;
+        }
+
+        @Override
+        public Map<BlockPos, BlockEntity> copy(Map<BlockPos, BlockEntity> value) {
+            return new HashMap<>();
         }
     });
 
-    private static final TrackedData<HashMap<BlockPos, BlockEntity>> VESSEL_BLOCK_ENTITY_DATA = DataTracker.registerData(AbstractVesselEntity.class, new TrackedDataHandler<>() {
-        @Override
-        public void write(PacketByteBuf buf, HashMap<BlockPos, BlockEntity> value) {
-            buf.writeByteArray(SerializationUtils.serialize(value)); // converts the hashmap
-        }
+    static {
+        TrackedDataHandlerRegistry.register(VESSEL_MODEL_DATA.getType());
+        TrackedDataHandlerRegistry.register(VESSEL_BLOCK_ENTITY_DATA.getType());
+        assert TrackedDataHandlerRegistry.getId(VESSEL_BLOCK_ENTITY_DATA.getType()) != -1;
+    }
 
-        @Override
-        public HashMap<BlockPos, BlockEntity> read(PacketByteBuf buf) {
-            return SerializationUtils.deserialize(buf.readByteArray()); // probably reads the hashmap from buf
-        }
-
-        @Override
-        public HashMap<BlockPos, BlockEntity> copy(HashMap<BlockPos, BlockEntity> value) {
-            return value;
-        }
-    });
+    public static void initClass() { //need to register ^ somehow it doesent normally??
+    }
 
     @Override
     public void readCustomDataFromNbt(NbtCompound nbt) {
@@ -135,11 +164,6 @@ public abstract class AbstractVesselEntity extends MobEntity {
         dataTracker.startTracking(VESSEL_BLOCK_ENTITY_DATA, new HashMap<>());
     }
 
-    static {
-        TrackedDataHandlerRegistry.register(VESSEL_MODEL_DATA.getType());
-        TrackedDataHandlerRegistry.register(VESSEL_BLOCK_ENTITY_DATA.getType());
-    }
-
     public AbstractVesselEntity(EntityType<? extends MobEntity> entityType, World world) {
         super(entityType, world);
         this.noClip = false;
@@ -170,6 +194,7 @@ public abstract class AbstractVesselEntity extends MobEntity {
             );
         }
         this.setRelativeVesselBlockPositions(this.relativeVesselBlockPositions);
+
         setModelData = true;
     }
 
@@ -246,21 +271,23 @@ public abstract class AbstractVesselEntity extends MobEntity {
         super.takeKnockback(0, 0, 0);
     }
 
-    public HashMap<BlockPos, BlockState> getRelativeVesselBlockPositions() {
+    public Map<BlockPos, BlockState> getRelativeVesselBlockPositions() {
         return dataTracker.get(VESSEL_MODEL_DATA);
     }
 
-    public HashMap<BlockPos, BlockEntity> getRelativeVesselBlockEntity() {
+    public Map<BlockPos, BlockEntity> getRelativeVesselBlockEntity() {
         return dataTracker.get(VESSEL_BLOCK_ENTITY_DATA);
     }
 
-    public void setRelativeVesselBlockPositions(HashMap<BlockPos, BlockState> relativeVesselBlockPositions) {
+    public void setRelativeVesselBlockPositions(Map<BlockPos, BlockState> relativeVesselBlockPositions) {
         this.relativeVesselBlockPositions = relativeVesselBlockPositions;
+        dataTracker.set(VESSEL_MODEL_DATA, Collections.emptyMap()); // maps are mutable
         dataTracker.set(VESSEL_MODEL_DATA, relativeVesselBlockPositions);
     }
 
-    public void setRelativeVesselBlockEntity(HashMap<BlockPos, BlockEntity> relativeVesselBlockEntity) {
+    public void setRelativeVesselBlockEntity(Map<BlockPos, BlockEntity> relativeVesselBlockEntity) {
         this.relativeVesselBlockEntity = relativeVesselBlockEntity;
+        dataTracker.set(VESSEL_BLOCK_ENTITY_DATA, Collections.emptyMap()); // maps are mutable
         dataTracker.set(VESSEL_BLOCK_ENTITY_DATA, relativeVesselBlockEntity);
     }
 

--- a/src/main/java/dev/sebastianb/wackyvessels/entity/vessels/AbstractVesselEntity.java
+++ b/src/main/java/dev/sebastianb/wackyvessels/entity/vessels/AbstractVesselEntity.java
@@ -88,7 +88,7 @@ public abstract class AbstractVesselEntity extends MobEntity {
 
         @Override
         public Map<BlockPos, BlockEntity> copy(Map<BlockPos, BlockEntity> value) {
-            return new HashMap<>();
+            return new HashMap<>(value);
         }
     });
 


### PR DESCRIPTION
- For some reason `DataTracker`s were not registered - the class wasn't initialized somehow
- Dropped `SerializationUtils.serialize` as it only works on `Object`s that `implement` `Serializable` (which is not implemented by `BlockPos`, `BlockState`  and all the different types of `BlockEntity`s, ( it could also be [exploited](https://snyk.io/blog/serialization-and-deserialization-in-java/) by malicious servers to run code on clients-it uses Object I/O streams)
- Fixes the copy methods - they didn't actually copy (it would be fine for primitives + immutable types, but `Map`s are mutable)
- Rather than asking the client to send the position of the vessel, the packet utilizes the knowledge about the position that it already has